### PR TITLE
Pass parties as an object to step functions

### DIFF
--- a/src/Protocol.js
+++ b/src/Protocol.js
@@ -143,7 +143,7 @@ class ProtocolInstance {
       }
 
       if (value.origin === this.principal) {
-        this.result = await value.function(...Object.values(this.parties))
+        this.result = await value.function(this.parties)
       } else if (value.recipients.includes(this.principal)) {
         const data = await new Promise((resolve, reject) => {
           this.resolve = resolve


### PR DESCRIPTION
I've updated the behavior of the Babel transformer to pick out parties from the step function as object properties, in https://github.com/ProtoBlocks/Evaluation/commit/a2f7186f08638e6f379a23a4a9ed79394d6f667f.

This is a small change to pass through the `this.parties` object directly into the step function.